### PR TITLE
Hardcode http2 max_concurrent_streams into gateway

### DIFF
--- a/pilot/pkg/networking/core/v1alpha3/gateway.go
+++ b/pilot/pkg/networking/core/v1alpha3/gateway.go
@@ -27,6 +27,7 @@ import (
 	http_conn "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
 	multierror "github.com/hashicorp/go-multierror"
 
+	google_protobuf "github.com/gogo/protobuf/types"
 	networking "istio.io/api/networking/v1alpha3"
 	"istio.io/istio/pilot/pkg/model"
 	istio_route "istio.io/istio/pilot/pkg/networking/core/v1alpha3/route"
@@ -350,6 +351,10 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 						Dns:     true,
 					},
 					ServerName: EnvoyServerName,
+					// TODO: This should be configurable and likely only set on http2 protos.
+					Http2ProtocolOptions: &core.Http2ProtocolOptions{
+						MaxConcurrentStreams: &google_protobuf.UInt32Value{Value: 65536},
+					},
 				},
 			},
 		}
@@ -383,6 +388,10 @@ func (configgen *ConfigGeneratorImpl) createGatewayHTTPFilterChainOpts(
 					Dns:     true,
 				},
 				ServerName: EnvoyServerName,
+				// TODO: This should be configurable and likely only set on http2 protos.
+				Http2ProtocolOptions: &core.Http2ProtocolOptions{
+					MaxConcurrentStreams: &google_protobuf.UInt32Value{Value: 65536},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
# Why
The default of 100 max concurrent streams on gateway listeners is insufficient and appears to be currently unconfigurable via `destinationrules`, `envoyfilters` or otherwise.

# How
For every gateway listener Pilot generates, hardcode:
```
Http2ProtocolOptions: &core.Http2ProtocolOptions{
  MaxConcurrentStreams: &google_protobuf.UInt32Value{Value: 65536},
}
```

- It should not be a problem if this is configured on a non-http2 capable port as the settings should be ignored.
- This can be made configurable by a setting on the `Gateway` CRD in the future.